### PR TITLE
Add OpenAI-compatible provider option (BYO model endpoint)

### DIFF
--- a/app/components/AgentSidebar.svelte
+++ b/app/components/AgentSidebar.svelte
@@ -319,6 +319,25 @@
 		localStorage.setItem('selectedModel', selectedModel)
 	}
 
+	function getSelectedProviderConfig(model = selectedModel) {
+		if (typeof localStorage === 'undefined') {
+			return { provider: 'anthropic', model }
+		}
+
+		const provider = localStorage.getItem('selectedAiProvider')
+
+		if (provider === 'openai-compatible') {
+			return {
+				provider,
+				model: localStorage.getItem('openaiCompatibleModel')?.trim() || model,
+				baseURL: localStorage.getItem('openaiCompatibleBaseUrl')?.trim() || '',
+				apiKey: localStorage.getItem('aiToken_openai-compatible')?.trim() || ''
+			}
+		}
+
+		return { provider: 'anthropic', model }
+	}
+
 	async function handleStreamingChunk(data, { type } = {}) {
 		try {
 			console.log('handleStreamingChunk called with data:', data)
@@ -967,6 +986,7 @@
 			userMessage,
 			selectedTarget,
 			selectedModel,
+			providerConfig: getSelectedProviderConfig(selectedModel),
 			timestamp: new Date().toISOString(),
 			status: 'queued', // queued, processing, completed
 			paused: false // Add paused state for individual items
@@ -1018,6 +1038,9 @@
 	}
 
 	async function processMessage(queueItem) {
+		const providerConfig = queueItem.providerConfig || getSelectedProviderConfig(queueItem.selectedModel)
+		const activeModel = providerConfig.model || queueItem.selectedModel
+
 		// Add user message to history
 		const messageId = queueItem.id
 		const userMessage = {
@@ -1025,7 +1048,7 @@
 			role: 'user',
 			content: queueItem.userMessage,
 			timestamp: queueItem.timestamp,
-			model: queueItem.selectedModel
+			model: activeModel
 		}
 		
 		chatHistory = [...chatHistory, userMessage]
@@ -1043,13 +1066,14 @@
 					init: {
 						body: JSON.stringify({
 							id: crypto.randomUUID(),
+							...providerConfig,
 							messages: [
 								{
 									id: crypto.randomUUID(),
 									createdAt: new Date().toISOString(),
 									role: 'user',
 									content: queueItem.userMessage,
-									model: queueItem.selectedModel,
+									model: activeModel,
 									parts: [{ type: 'text', text: 'user context: ' + JSON.stringify(contextMetadata) + '\n\n' }, { type: 'text', text: queueItem.userMessage }]
 								}
 							]
@@ -1542,17 +1566,20 @@
         }
 
 		// Construct the message payload with tool invocation result
-		console.log('Sending model to backend:', selectedModel)
+		const providerConfig = getSelectedProviderConfig(selectedModel)
+		const activeModel = providerConfig.model || selectedModel
+		console.log('Sending model to backend:', activeModel)
 		const messagePayload = {
 			id: crypto.randomUUID(),
-			model: selectedModel,
+			...providerConfig,
+			model: activeModel,
 			messages: [
 				{
 					id: userMessage.id,
 					createdAt: userMessage.timestamp,
 					role: 'user',
 					content: userMessage.content,
-					model: selectedModel,
+					model: activeModel,
 					parts: [{
 						type: 'text',
 						text: userMessage.content
@@ -1672,17 +1699,20 @@
 		}
 		
 		// Construct the message payload with tool invocation result
-		console.log('Sending model to backend:', selectedModel)
+		const providerConfig = getSelectedProviderConfig(selectedModel)
+		const activeModel = providerConfig.model || selectedModel
+		console.log('Sending model to backend:', activeModel)
 		const messagePayload = {
 			id: crypto.randomUUID(),
-			model: selectedModel,
+			...providerConfig,
+			model: activeModel,
 			messages: [
 				{
 					id: userMessage.id,
 					createdAt: userMessage.timestamp,
 					role: 'user',
 					content: userMessage.content,
-					model: selectedModel,
+					model: activeModel,
 					parts: [{
 						type: 'text',
 						text: userMessage.content

--- a/app/components/Settings.svelte
+++ b/app/components/Settings.svelte
@@ -10,6 +10,8 @@
     let selectedAiProvider = $state('writer')
     let customSearchUrl = $state('')
     let customNewTabUrl = $state('')
+    let openaiCompatibleBaseUrl = $state('')
+    let openaiCompatibleModel = $state('')
     let syncServerUrl = $state('https://darc.cloudless.one')
     let syncServerToken = $state('')
     let exportDirectory = $state(null)
@@ -21,6 +23,7 @@
     let aiTokens = $state({
         gemini: '',
         openai: '',
+        'openai-compatible': '',
         anthropic: '',
         elevenlabs: ''
     })
@@ -89,6 +92,12 @@
             description: 'Cloud-based agent model',
             icon: 'https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://openai.com&size=64'
         },
+        {
+            id: 'openai-compatible',
+            name: 'OpenAI-compatible',
+            description: 'Custom endpoint, model, and API key',
+            icon: 'https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://openai.com&size=64'
+        },
         { 
             id: 'anthropic', 
             name: 'Anthropic Claude', 
@@ -115,6 +124,9 @@
     const enabledProviders = $derived.by(() => {
         return aiProviders.filter(provider => {
             if (provider.id === 'writer' || provider.id === 'disabled') return true
+            if (provider.id === 'openai-compatible') {
+                return aiTokens[provider.id]?.trim() && openaiCompatibleBaseUrl.trim() && openaiCompatibleModel.trim()
+            }
             return aiTokens[provider.id]?.trim()
         })
     })
@@ -438,6 +450,26 @@
         
         // If the currently selected provider's token is cleared, switch to writer
         if (selectedAiProvider === providerId && !token.trim()) {
+            selectedAiProvider = 'writer'
+            localStorage.setItem('selectedAiProvider', 'writer')
+        }
+    }
+
+    function handleOpenAICompatibleBaseUrlChange(url) {
+        openaiCompatibleBaseUrl = url
+        localStorage.setItem('openaiCompatibleBaseUrl', url)
+
+        if (selectedAiProvider === 'openai-compatible' && !url.trim()) {
+            selectedAiProvider = 'writer'
+            localStorage.setItem('selectedAiProvider', 'writer')
+        }
+    }
+
+    function handleOpenAICompatibleModelChange(model) {
+        openaiCompatibleModel = model
+        localStorage.setItem('openaiCompatibleModel', model)
+
+        if (selectedAiProvider === 'openai-compatible' && !model.trim()) {
             selectedAiProvider = 'writer'
             localStorage.setItem('selectedAiProvider', 'writer')
         }
@@ -869,9 +901,12 @@ To import this data back into DARC, use the import function in Settings.
         customNewTabUrl = ''
         syncServerUrl = 'https://darc.cloudless.one'
         syncServerToken = ''
+        openaiCompatibleBaseUrl = ''
+        openaiCompatibleModel = ''
         aiTokens = {
             gemini: '',
             openai: '',
+            'openai-compatible': '',
             anthropic: '',
             elevenlabs: ''
         }
@@ -881,6 +916,8 @@ To import this data back into DARC, use the import function in Settings.
         localStorage.removeItem('selectedAiProvider')
         localStorage.removeItem('customSearchUrl')
         localStorage.removeItem('customNewTabUrl')
+        localStorage.removeItem('openaiCompatibleBaseUrl')
+        localStorage.removeItem('openaiCompatibleModel')
         localStorage.removeItem('syncServerUrl')
         localStorage.removeItem('syncServerToken')
         
@@ -900,6 +937,8 @@ To import this data back into DARC, use the import function in Settings.
         const savedAiProvider = localStorage.getItem('selectedAiProvider')
         const savedCustomSearchUrl = localStorage.getItem('customSearchUrl')
         const savedCustomNewTabUrl = localStorage.getItem('customNewTabUrl')
+        const savedOpenAICompatibleBaseUrl = localStorage.getItem('openaiCompatibleBaseUrl')
+        const savedOpenAICompatibleModel = localStorage.getItem('openaiCompatibleModel')
         const savedSyncServerUrl = localStorage.getItem('syncServerUrl')
 
         if (savedSearchEngine) defaultSearchEngine = savedSearchEngine
@@ -907,6 +946,8 @@ To import this data back into DARC, use the import function in Settings.
         if (savedAiProvider) selectedAiProvider = savedAiProvider
         if (savedCustomSearchUrl) customSearchUrl = savedCustomSearchUrl
         if (savedCustomNewTabUrl) customNewTabUrl = savedCustomNewTabUrl
+        if (savedOpenAICompatibleBaseUrl) openaiCompatibleBaseUrl = savedOpenAICompatibleBaseUrl
+        if (savedOpenAICompatibleModel) openaiCompatibleModel = savedOpenAICompatibleModel
         if (savedSyncServerUrl) syncServerUrl = savedSyncServerUrl
         
         // Load AI tokens
@@ -972,11 +1013,27 @@ To import this data back into DARC, use the import function in Settings.
                                  onclick={(e) => e.stopPropagation()}
                                  onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') e.stopPropagation() }}
                                  role="presentation">
+                                {#if provider.id === 'openai-compatible'}
+                                    <input
+                                        type="url"
+                                        bind:value={openaiCompatibleBaseUrl}
+                                        oninput={(e) => handleOpenAICompatibleBaseUrlChange(e.target.value)}
+                                        placeholder="Base URL"
+                                        class="ai-token-input"
+                                    />
+                                    <input
+                                        type="text"
+                                        bind:value={openaiCompatibleModel}
+                                        oninput={(e) => handleOpenAICompatibleModelChange(e.target.value)}
+                                        placeholder="Model name"
+                                        class="ai-token-input"
+                                    />
+                                {/if}
                                 <input 
                                     type="password"
                                     bind:value={aiTokens[provider.id]}
                                     oninput={(e) => handleAiTokenChange(provider.id, e.target.value)}
-                                    placeholder="API Token"
+                                    placeholder={provider.id === 'openai-compatible' ? 'API Key' : 'API Token'}
                                     class="ai-token-input"
                                 />
                             </div>
@@ -1701,6 +1758,9 @@ To import this data back into DARC, use the import function in Settings.
 
     /* AI Token Input Styles */
     .token-input-section {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
         margin-top: 8px;
         width: 100%;
     }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "packageManager": "pnpm@10.13.1",
   "dependencies": {
     "@ai-sdk/anthropic": "2.0.8",
+    "@ai-sdk/openai": "2.0.8",
     "@ai-sdk/ui-utils": "1.2.11",
     "@cloudflare/vite-plugin": "1.7.4",
     "@elevenlabs/client": "^0.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: 2.0.8
         version: 2.0.8(zod@3.25.76)
+      '@ai-sdk/openai':
+        specifier: 2.0.8
+        version: 2.0.8(zod@3.25.76)
       '@ai-sdk/ui-utils':
         specifier: 1.2.11
         version: 1.2.11(zod@3.25.76)
@@ -119,11 +122,23 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4
 
+  '@ai-sdk/openai@2.0.8':
+    resolution: {integrity: sha512-D5AP65yCXL4GtTrWGhu3hTHhlKyYu8NBRtRZ1h5F8PYXFVLtuiQ0AypbDreXLphONehLf0zGN3Cm3Fob/DDMRw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
   '@ai-sdk/provider-utils@2.2.8':
     resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.23.8
+
+  '@ai-sdk/provider-utils@3.0.1':
+    resolution: {integrity: sha512-/iP1sKc6UdJgGH98OCly7sWJKv+J9G47PnTjIj40IJMUQKwDrUMyf7zOOfRtPwSuNifYhSoJQ4s1WltI65gJ/g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
 
   '@ai-sdk/provider-utils@3.0.7':
     resolution: {integrity: sha512-o3BS5/t8KnBL3ubP8k3w77AByOypLm+pkIL/DCw0qKkhDbvhCy+L3hRTGPikpdb8WHcylAeKsjgwOxhj4cqTUA==}
@@ -1510,6 +1525,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
@@ -2737,6 +2753,7 @@ packages:
 
   sliced@1.0.1:
     resolution: {integrity: sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==}
+    deprecated: Unsupported
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -2818,6 +2835,7 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   text-decoder@1.2.3:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
@@ -3195,12 +3213,26 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.7(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/openai@2.0.8(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.1(zod@3.25.76)
+      zod: 3.25.76
+
   '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
       zod: 3.25.76
+
+  '@ai-sdk/provider-utils@3.0.1(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@standard-schema/spec': 1.0.0
+      eventsource-parser: 3.0.5
+      zod: 3.25.76
+      zod-to-json-schema: 3.24.6(zod@3.25.76)
 
   '@ai-sdk/provider-utils@3.0.7(zod@3.25.76)':
     dependencies:

--- a/workerd/worker.ts
+++ b/workerd/worker.ts
@@ -25,8 +25,8 @@ interface ExportedHandler<Env = unknown> {
 //   type StreamTextOnFinishCallback,
 //   type ToolSet
 // } from "ai"
-import { anthropic } from "@ai-sdk/anthropic"; // createAnthropic
-// import { openai } from "@ai-sdk/openai";
+import { anthropic, createAnthropic } from "@ai-sdk/anthropic";
+import { createOpenAI } from "@ai-sdk/openai";
 // import { processToolCalls } from "./utils"
 // import { tools, executions } from "./tools"
 // import { env } from "cloudflare:workers";
@@ -62,16 +62,34 @@ function addCorsHeaders(response: Response): Response {
 // claude-3-7-sonnet-20250219
 // claude-4-sonnet-20250514
 
+type ModelConfig = {
+  provider?: string;
+  model?: string;
+  baseURL?: string;
+  apiKey?: string;
+}
+
 // Function to get model instance only when needed
-function getModel(modelId: string = 'claude-4-sonnet-20250514') {
-  console.log('Using model:', modelId)
-  switch (modelId) {
-    case 'claude-4-sonnet-20250514':
-      return anthropic('claude-4-sonnet-20250514')
-    case 'claude-3-5-haiku-20241022':
-    default:
-      return anthropic('claude-4-sonnet-20250514')
+function getModel({
+  provider = 'anthropic',
+  model = 'claude-4-sonnet-20250514',
+  baseURL,
+  apiKey
+}: ModelConfig = {}) {
+  console.log('Using model:', { provider, model, baseURL })
+
+  if (provider === 'openai-compatible') {
+    const openai = createOpenAI({
+      apiKey,
+      baseURL
+    })
+
+    return openai(model)
   }
+
+  const anthropicProvider = apiKey ? createAnthropic({ apiKey }) : anthropic
+
+  return anthropicProvider(model)
 }
 
 // Cloudflare AI Gateway
@@ -117,7 +135,7 @@ function getModel(modelId: string = 'claude-4-sonnet-20250514') {
 //         // Use the model set by onMessage
 //         const modelToUse = '' // FIXME: hwo to get this from the user? his.selectedModel;
         
-//         const selectedModel = getModel(modelToUse)
+//         const selectedModel = getModel({ model: modelToUse })
 
 //         console.log('Using model:', {modelToUse, selectedModel})
         

--- a/workerd/worker.ts
+++ b/workerd/worker.ts
@@ -88,8 +88,10 @@ function getModel({
   }
 
   const anthropicProvider = apiKey ? createAnthropic({ apiKey }) : anthropic
+  // guard: non-Anthropic ids (e.g. openai-o3 from the picker) would 400 against the Anthropic API
+  const anthropicModel = model.startsWith('claude') ? model : 'claude-4-sonnet-20250514'
 
-  return anthropicProvider(model)
+  return anthropicProvider(anthropicModel)
 }
 
 // Cloudflare AI Gateway


### PR DESCRIPTION
Implements decision 004 (minimum-viable bring-your-own-model — sovereignty litmus item 3).

## What
- Settings: 'OpenAI-compatible' provider card — base URL, model name, API key (persisted via existing localStorage patterns)
- Sidebar: chat payload carries {provider, model, baseURL, apiKey} when that provider is selected
- workerd getModel(): supports createOpenAI({apiKey, baseURL}); Anthropic path unchanged
- Fix: model picker selections (haiku/opus) were silently coerced to Sonnet; now honored — **note: this un-gates Opus spend, flag if the coercion was intentional**
- Known debt (pre-existing, unchanged): tokens in plaintext localStorage

## Point it at Folknet
Base URL `http://10.54.0.64:8020/v1` (or the CT206:4000 router once W2 lands), any key, model `default`.

## Process
Worker: gpt-5.5 (codex, packet P-002) · Validator: opus-4.8 — SHIP-WITH-FIXES, both fixes applied (pnpm-lock entry, non-Claude id guard). Caveat: chat backend in this repo is currently commented-out scaffolding; wiring validated statically, end-to-end test pending live backend (darc-worker?).

🤖 Generated with [Claude Code](https://claude.com/claude-code)